### PR TITLE
Handle Missing year for unconfirmed / unknown releases

### DIFF
--- a/redactedapi.py
+++ b/redactedapi.py
@@ -220,7 +220,10 @@ class RedactedAPI:
         form.find_control('file_input').add_file(open(new_torrent), 'application/x-bittorrent', os.path.basename(new_torrent))
         #if torrent['remastered']:
         #    form.find_control('remaster').set_single('1')
-        form['remaster_year'] = str(torrent['remasterYear'])
+        if torrent['remasterYear'] != 0:
+            form['remaster_year'] = str(torrent['remasterYear'])
+        else:
+            form['remaster_year'] = str(group['group']['year'])
         form['remaster_title'] = torrent['remasterTitle']
         form['remaster_record_label'] = torrent['remasterRecordLabel']
         form['remaster_catalogue_number'] = torrent['remasterCatalogueNumber']

--- a/redactedbetter
+++ b/redactedbetter
@@ -69,6 +69,7 @@ def main():
     parser.add_argument('--cache', help='the location of the cache', \
             default=os.path.expanduser('~/.redactedbetter/cache'))
     parser.add_argument('-U', '--no-upload', action='store_true', help='don\'t upload new torrents (in case you want to do it manually)')
+    parser.add_argument('-Y', '--force-year', action='store_true', help='process releases without year (unknown or unconfirmed)')
     parser.add_argument('-E', '--no-24bit-edit', action='store_true', help='don\'t try to edit 24-bit torrents mistakenly labeled as 16-bit')
     parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
@@ -127,6 +128,7 @@ def main():
             supported_media = redactedapi.lossless_media
 
     upload_torrent = not args.no_upload
+    force_year = args.force_year
 
     print 'Logging in to RED...'
     api = redactedapi.RedactedAPI(username, password, session_cookie)
@@ -150,7 +152,7 @@ def main():
         if group != None:
             torrent = [t for t in group['torrents'] if t['id'] == torrentid][0]
 
-            artist = "";
+            artist = ""
             if len(group['group']['musicInfo']['artists']) > 1:
                 artist = "Various Artists"
             else:
@@ -158,7 +160,11 @@ def main():
 
             year = str(torrent['remasterYear'])
             if year == "0":
-                year = str(group['group']['year'])
+                if force_year:
+                    year = str(group['group']['year'])
+                else:
+                    print "Skipping because release has no year set: " + artist + " - " + redactedapi.unescape(group['group']['name'])
+                    continue
 
             releaseartist = "Release artist(s): %s" % artist
             releasename   = "Release name     : %s" % redactedapi.unescape(group['group']['name'])


### PR DESCRIPTION
As highlighted in #15 unconfirmed or unknown releases cannot be uploaded because of the missing year, which is mandatory, but those are still being transcoded, wasting some CPU time for nothing.

This PR introduces a new command line argument `-Y` or `--force-year`:
- when set, the transcode will happen like before, but the upload will be done by forcing the year of the torrent by using the one of the group. The problem with that is the new torrent will not be in the same group has the source of the transcode. This should require a manual action from staff to correct the newly added torrent and mark it as Unconfirmed.
- when not set (default), the whole torrent will be skipped entirely, and won't be transcoded.