### PR TITLE
--no-prompt command line option for unattended mode

### DIFF
--- a/redactedbetter
+++ b/redactedbetter
@@ -69,6 +69,7 @@ def main():
     parser.add_argument('--cache', help='the location of the cache', \
             default=os.path.expanduser('~/.redactedbetter/cache'))
     parser.add_argument('-U', '--no-upload', action='store_true', help='don\'t upload new torrents (in case you want to do it manually)')
+    parser.add_argument('-P', '--no-prompt', action='store_true', help='don\'t prompt for user input (to run unattended)')
     parser.add_argument('-E', '--no-24bit-edit', action='store_true', help='don\'t try to edit 24-bit torrents mistakenly labeled as 16-bit')
     parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
@@ -127,6 +128,7 @@ def main():
             supported_media = redactedapi.lossless_media
 
     upload_torrent = not args.no_upload
+    no_prompt = args.no_prompt
 
     print 'Logging in to RED...'
     api = redactedapi.RedactedAPI(username, password, session_cookie)
@@ -193,6 +195,9 @@ def main():
                             print "Release is actually 24-bit lossless, skipping."
                             continue
                         if int(do_24_bit) == 1:
+                            if no_prompt:
+                                print "No prompt: Mark release as 24bit lossless? y/n => n"
+                                continue
                             confirmation = raw_input("Mark release as 24bit lossless? y/n: ")
                             if confirmation != 'y':
                                 continue
@@ -229,7 +234,10 @@ def main():
 
             while os.path.exists(flac_dir) == False:
                 print "Path not found: %s" % flac_dir
-                alternative_file_path_exists = ""
+                if no_prompt:
+                    alternative_file_path_exists = "n"
+                else:
+                    alternative_file_path_exists = ""
                 while (alternative_file_path_exists.lower() != "y") and (alternative_file_path_exists.lower() != "n"):
                     alternative_file_path_exists = raw_input("Do you wish to provide an alternative file path? (y/n): ")
 
@@ -249,8 +257,8 @@ def main():
                         else:
                             basename = artist + " - " + group['group']['name'] + " [" + year + "] (" + torrent['media'] + " - "
 
-                        transcode_dir = transcode.transcode_release(flac_dir, output_dir, basename, format, max_threads=args.threads)
-                        if transcode_dir == False:
+                        transcode_dir = transcode.transcode_release(flac_dir, output_dir, basename, format, max_threads=args.threads, no_prompt=no_prompt)
+                        if not transcode_dir:
                             print "Skipping - some file(s) in this release were incorrectly marked as 24bit."
                             break
 

--- a/transcode.py
+++ b/transcode.py
@@ -264,18 +264,18 @@ def get_basename_suffix(basename, output_format):
 
 
 def get_transcode_dir(flac_dir, output_dir, basename, output_format, resample, no_prompt):
-    newbasename = get_basename_suffix(basename)
+    newbasename = get_basename_suffix(basename, output_format)
     newbasename = get_suitable_basename(newbasename)
 
     if no_prompt:
         if path_length_exceeds_limit(flac_dir, newbasename):
             print "The file paths in this torrent exceed the 180 character limit. \n\
-                The current directory name is: " + get_suitable_basename(newbasename.decode('utf-8')) + "\n"
+                The current directory name is: " + get_suitable_basename(newbasename.decode('utf-8'))
             shortened_basename = basename
             while path_length_exceeds_limit(flac_dir, newbasename):
                 shortened_basename = shortened_basename[:-1]
-                newbasename = get_suitable_basename(get_basename_suffix(shortened_basename))
-            print "Shortened directory name: " + newbasename
+                newbasename = get_suitable_basename(get_basename_suffix(shortened_basename, output_format))
+            print "Auto-shortened directory name: " + newbasename
 
     else:
         while path_length_exceeds_limit(flac_dir, newbasename):


### PR DESCRIPTION
This adds a `-P` `--no-prompt` command line option that will remove all prompts for user input:
- if the directory is not found, the release will be skipped
- if the torrent contains filenames (directory + filename) that are over 180 characters, the script will auto-shorten the directory name
- if the release is actually FLAC 24bits, it will skip editing the existing torrent to mark it as such