### PR TITLE
change folder name sanitization to allow CJK

### DIFF
--- a/redactedbetter
+++ b/redactedbetter
@@ -151,6 +151,7 @@ def main():
             torrent = [t for t in group['torrents'] if t['id'] == torrentid][0]
 
             artist = "";
+            name = redactedapi.unescape(group['group']['name'])
             if len(group['group']['musicInfo']['artists']) > 1:
                 artist = "Various Artists"
             else:
@@ -161,7 +162,7 @@ def main():
                 year = str(group['group']['year'])
 
             releaseartist = "Release artist(s): %s" % artist
-            releasename   = "Release name     : %s" % redactedapi.unescape(group['group']['name'])
+            releasename   = "Release name     : %s" % name
             releaseyear   = "Release year     : %s" % year
             releaseurl    = "Release URL      : %s" % api.release_url(group, torrent)
 
@@ -174,7 +175,7 @@ def main():
                     print "Path not found - skipping: %s" % flac_file
                     continue
                 flac_dir = os.path.join(data_dir, "%s (%s) [FLAC]" % (
-                redactedapi.unescape(group['group']['name']), group['group']['year']))
+                name, group['group']['year']))
                 if not os.path.exists(flac_dir):
                     os.makedirs(flac_dir)
                 shutil.copy(flac_file, flac_dir)
@@ -245,9 +246,9 @@ def main():
                     tmpdir = tempfile.mkdtemp()
                     try:
                         if len(torrent['remasterTitle']) >= 1:
-                            basename = artist + " - " + group['group']['name'] + " (" + torrent['remasterTitle'] + ") " + "[" + year + "] (" + torrent['media'] + " - "
+                            basename = artist + " - " + name + " (" + torrent['remasterTitle'] + ") " + "[" + year + "] (" + torrent['media'] + " - "
                         else:
-                            basename = artist + " - " + group['group']['name'] + " [" + year + "] (" + torrent['media'] + " - "
+                            basename = artist + " - " + name + " [" + year + "] (" + torrent['media'] + " - "
 
                         transcode_dir = transcode.transcode_release(flac_dir, output_dir, basename, format, max_threads=args.threads)
                         if transcode_dir == False:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mechanize==0.2.5
 mutagen>=1.20
 requests>=1.0
-Unidecode>=1.0.23

--- a/test_transcode.py
+++ b/test_transcode.py
@@ -13,7 +13,7 @@ class TestGetSuitableBasename(unittest.TestCase):
     def test_japanese(self):
         name = u'Nihon Kogakuin College (日本工学院専門学校) - (1985) Pink Papaia {NKS MD8503A 24-96 Vinyl} [FLAC]'
         expected = name
-        actual = transcode.get_suitable_basename(name)
+        actual = unicode(transcode.get_suitable_basename(name),"utf-8")
         self.assertEqual(expected, actual)
 
     def test_illegal_characters(self):

--- a/test_transcode.py
+++ b/test_transcode.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+import unittest
+import transcode
+
+
+class TestGetSuitableBasename(unittest.TestCase):
+    def test_ascii(self):
+        name = 'Artist - Album (2000) [FLAC]'
+        expected = name
+        actual = transcode.get_suitable_basename(name)
+        self.assertEqual(expected, actual)
+
+    def test_japanese(self):
+        name = u'Nihon Kogakuin College (日本工学院専門学校) - (1985) Pink Papaia {NKS MD8503A 24-96 Vinyl} [FLAC]'
+        expected = name
+        actual = transcode.get_suitable_basename(name)
+        self.assertEqual(expected, actual)
+
+    def test_illegal_characters(self):
+        name = 'fi:l*e/p\"a?t>h|.t<xt \0_abc<d>e%f/(g)h+i_0.txt'
+        expected = 'fi,lepath.txt _abcde%f(g)h+i_0.txt'
+        actual = transcode.get_suitable_basename(name)
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/transcode.py
+++ b/transcode.py
@@ -243,7 +243,7 @@ def path_length_exceeds_limit(flac_dir, basename):
     return False
 
 def get_suitable_basename(basename):
-	return basename.replace('\0', '').replace('\\', ',').replace('/', '').replace(':', ',').replace('*', '').replace('?', '').replace('"', '').replace('<', '').replace('>', '').replace('|', '')
+	return basename.replace('\0', '').replace('\\', ',').replace('/', '').replace(':', ',').replace('*', '').replace('?', '').replace('"', '').replace('<', '').replace('>', '').replace('|', '').encode("utf-8")
 
 def get_transcode_dir(flac_dir, output_dir, basename, output_format, resample):
     if output_format == "FLAC":

--- a/transcode.py
+++ b/transcode.py
@@ -9,8 +9,6 @@ import shutil
 import signal
 import subprocess
 import sys
-from HTMLParser import HTMLParser
-import unidecode
 
 import mutagen.flac
 
@@ -245,8 +243,7 @@ def path_length_exceeds_limit(flac_dir, basename):
     return False
 
 def get_suitable_basename(basename):
-	h = HTMLParser()
-	return unidecode.unidecode(h.unescape(basename).replace('\\', ',').replace('/', ',').replace(':', ',').replace('*', '').replace('?', '').replace('"', '').replace('<', '').replace('>', '').replace('|', ''))
+	return basename.replace('\0', '').replace('\\', ',').replace('/', '').replace(':', ',').replace('*', '').replace('?', '').replace('"', '').replace('<', '').replace('>', '').replace('|', '')
 
 def get_transcode_dir(flac_dir, output_dir, basename, output_format, resample):
     if output_format == "FLAC":


### PR DESCRIPTION
- Removed `unidecode` which would romanize the CJK characters.
- Removed `HTMLParser().unescape`, it didn't had any effect on my test cases
- Add removal of the `NULL` (`\0` in Python) character which was not handled before
- `/` is not replaced by empty string instead of `,`

This should remove the risk of warnings with releases containing CJK characters.

cc @undaunt